### PR TITLE
renamed "sr-mg" to "mg" ?

### DIFF
--- a/sinatra-content-for.gemspec
+++ b/sinatra-content-for.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:add_development_dependency)
     s.add_development_dependency "contest"
-    s.add_development_dependency "sr-mg"
+    s.add_development_dependency "mg"
     s.add_development_dependency "redgreen"
   end
 


### PR DESCRIPTION
It is an error at bundle install.

> Could not find gem 'sr-mg (>= 0) ruby', which is required by gem 'sinatra-content-for (>= 0) ruby', in any of the sources.

sr-mg is renamed ?
